### PR TITLE
Upgrading -  Update Gluster version to 9, change gluster.cluster role dependency to use official ansible-galaxy's gluster.gluster collection for gluster volume support

### DIFF
--- a/001.requirements.yml
+++ b/001.requirements.yml
@@ -6,10 +6,10 @@
   become: no
   tasks:
     - name: "Install Ansible roles for GlusterFS"
-      shell: "ansible-galaxy install -r requirements.yml --force"
+      shell: "ansible-galaxy install -p $HOME/.ansible/roles -r requirements.yml --force"
 
     - name: "Install Ansible galaxy collection for GlusterFS volume support"
-      shell: "ansible-galaxy collection install gluster.gluster --force"
+      shell: "ansible-galaxy collection install -p $HOME/.ansible/roles gluster.gluster --force"
 
     - name: "Installing Jmespath through pip3"
       pip:

--- a/001.requirements.yml
+++ b/001.requirements.yml
@@ -6,7 +6,11 @@
   become: no
   tasks:
     - name: "Install Ansible roles for GlusterFS"
-      shell: "ansible-galaxy install -r requirements.yml"
+      shell: "ansible-galaxy install -r requirements.yml --force"
+
+    - name: "Install Ansible galaxy collection for GlusterFS volume support"
+      shell: "ansible-galaxy collection install gluster.gluster --force"
+
     - name: "Installing Jmespath through pip3"
       pip:
         name: jmespath

--- a/003.setup_glusterfs_cluster.yml
+++ b/003.setup_glusterfs_cluster.yml
@@ -51,17 +51,27 @@
     - name: Pause for 5 seconds to build  cache
       pause:
         seconds: 5
-  
-  vars:
-    # The transport type for the volume (tcp / rdma / tcp,rdma)
-    gluster_cluster_transport: 'tcp,rdma'
-    # Force option will be used while creating a volume, any warnings will be suppressed.
-    gluster_cluster_force: 'yes'
-    # Brick paths on servers. Multiple brick paths can be separated by commas.
-    gluster_cluster_bricks: '/mnt/brick1'
 
-    # Replica count while creating a volume. Currently replica 2 and replica 3 are supported.
-    #gluster_cluster_replica_count: '2'
+    - name: Start glusterd on the nodes if not already started
+      service:
+          state: started
+          name: glusterd
+          enabled: yes
+      delegate_to: "{{ item }}"
+      run_once: true
+      with_items: "{{ gluster_cluster_hosts }}"
 
-  roles:
-     - gluster.cluster
+    - name: create gluster volume
+      vars:
+        # Get the private ips for each host as a string where each host ip is seperated by a comma
+        glusterfs_cluster_private_ips: "{{ansible_play_hosts | map('extract', hostvars, ['ansible_eth0', 'ipv4', 'address']) | join(',') }}"
+        # Convert it to a list
+        gluster_cluster_private_hosts: "{{ glusterfs_cluster_private_ips.split(',') }}"
+      gluster.gluster.gluster_volume:
+        state: present
+        name: "{{ gluster_cluster_volume }}"
+        bricks: '/mnt/brick1'
+        force: true
+        transport: 'tcp,rdma'
+        cluster: "{{ gluster_cluster_private_hosts if gluster_cluster_private_hosts is defined and gluster_cluster_private_hosts | length > 0 else gluster_cluster_hosts}}"
+      run_once: true

--- a/003.setup_glusterfs_cluster.yml
+++ b/003.setup_glusterfs_cluster.yml
@@ -72,6 +72,6 @@
         name: "{{ gluster_cluster_volume }}"
         bricks: '/mnt/brick1'
         force: true
-        transport: 'tcp,rdma'
+        transport: 'tcp'
         cluster: "{{ gluster_cluster_private_hosts if gluster_cluster_private_hosts is defined and gluster_cluster_private_hosts | length > 0 else gluster_cluster_hosts}}"
       run_once: true

--- a/004.mount_glusterfs.yml
+++ b/004.mount_glusterfs.yml
@@ -15,7 +15,7 @@
 
     - name: Add new apt source
       apt_repository:
-        repo: deb https://download.gluster.org/pub/gluster/glusterfs/{{ glusterd_version }}/LATEST/Debian/stretch/amd64/apt stretch main
+        repo: ppa:gluster/glusterfs-{{ glusterd_version }}
         filename: gluster.list
         state: present
       when: ansible_os_family == 'Debian'

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -2,7 +2,7 @@
 glusterfs_daemon: "glusterd"
 glusterfs_cluster_public_ips: "{{ groups['gfscluster'] | map('extract', hostvars, ['ansible_host']) | join(',') }}"
 #glusterfs_cluster_private_ips: "{{ groups['gfscluster'] | map('extract', hostvars, ['ansible_eth0', 'ipv4', 'address']) | join(',') }}"
-glusterd_version: "7"
+glusterd_version: "9"
 # gluster cluster ips
 gluster_cluster_hosts: "{{ glusterfs_cluster_public_ips.split(',') }}"
 #gluster_cluster_private_hosts: "{{ glusterfs_cluster_private_ips.split(',') }}"

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,8 +5,3 @@
     # Download gluster.infra from git
     - name: gluster.infra
       src: https://github.com/gluster/gluster-ansible-infra
-    
-    # Download gluster.cluster from git
-    - name: gluster.cluster
-      src: https://github.com/achak1987/gluster-ansible-cluster
-      version: "aws_support"


### PR DESCRIPTION
**Upgrading -  Update Gluster version to 9, change gluster.cluster role dependency to use [official ansible-galaxy's gluster.gluster collection](https://docs.ansible.com/ansible/latest/collections/gluster/gluster/gluster_volume_module.html) for gluster volume support**

 - In `requirements.yml`, removed the task requirement for ansible-galaxy's install for gluster.cluster pointing to repo https://github.com/achak1987/gluster-ansible-cluster

 - In `001.requirements.yml`, 
   - added **"--force"** parameter to install ansible-galaxy requirements from the _requirements.yml_ file 
     
      This  --force option was added to reflect  new changes from the repositories specified in the _requiremments.yml_. Otherwise, if a repository has been already added to ansible-galaxy collection previously, it will skip importing new changes. **The "--force" options ensures always new changes are pulled from the specified repositories, whenever we run the playbook `001.requirements.yml`**
    
   - added a new task to **install the [official ansible-galaxy's gluster.gluster collection for gluster volume support.](https://docs.ansible.com/ansible/latest/collections/gluster/gluster/gluster_volume_module.html)**
       - This plugin is part of the [gluster.gluster collection](https://galaxy.ansible.com/gluster/gluster) (version 1.0.1) - [official github repository](https://github.com/gluster/gluster-ansible-collection).
       -  To install it use:` ansible-galaxy collection install gluster.gluster`.
       - To use it in a playbook, specify:` gluster.gluster.gluster_volume`. 

 - In `003.setup_glusterfs_cluster.yml`, **removed the role "gluster.cluster" and used the official [ansible-galaxy's gluster.gluster collection](https://docs.ansible.com/ansible/latest/collections/gluster/gluster/gluster_volume_module.html) for gluster volume support.**