### PR TITLE
Fixes Issue 15 - Gluster volume start fails while running playbook "003.setup_glusterfs_cluster.yml

### DIFF
--- a/003.setup_glusterfs_cluster.yml
+++ b/003.setup_glusterfs_cluster.yml
@@ -54,7 +54,7 @@
   
   vars:
     # The transport type for the volume (tcp / rdma / tcp,rdma)
-    gluster_cluster_transport: 'tcp,rdma'
+    gluster_cluster_transport: 'tcp'
     # Force option will be used while creating a volume, any warnings will be suppressed.
     gluster_cluster_force: 'yes'
     # Brick paths on servers. Multiple brick paths can be separated by commas.


### PR DESCRIPTION
**Fixes [Issue 15 ](https://github.com/bityoga/mysome_glusterfs/issues/15)- Gluster volume start fails while running playbook "003.setup_glusterfs_cluster.yml"**

- removed rdma support for gluster volume transport option

**The actual problem is problem with rdma transport support in glusterfs**

**Gluster volume not starting when the volume is created using transport options tcp,rdma (or) rdma**

- Gluster volume fails to start when rdma (or) tcp,rdma transport option is specified while creating gluster volume
- Volume starts successfully only when tcp alone is specified for transport

The issue  is related to glusterfs and i have raised it here https://github.com/gluster/glusterfs/issues/2776

**The  fix as of now is to remove rdma and use only tcp for transport option while creating gluster volume**