### PR TITLE
Fixes issue#19 - the role 'gluster.infra' was not found in awx executing ansible-galaxy

### DIFF
--- a/001.requirements.yml
+++ b/001.requirements.yml
@@ -6,7 +6,7 @@
   become: no
   tasks:
     - name: "Install Ansible roles for GlusterFS"
-      shell: "ansible-galaxy install -r requirements.yml"
+      shell: "ansible-galaxy install -p $HOME/.ansible/roles -r requirements.yml"
     - name: "Installing Jmespath through pip3"
       pip:
         name: jmespath


### PR DESCRIPTION
**Fixes i[ssue#19](https://github.com/bityoga/mysome_glusterfs/issues/19) - the role 'gluster.infra' was not found in awx executing ansible-galaxy**

- In awx executing ansible-galaxy runs on a temp directory that is deleted after the execution. To make sure we install the roles in ~/.ansible we added the $HOME var.

As Suggested by spiros here : https://github.com/bityoga/mysome_glusterfs/pull/14 