### PR TITLE
Fix issue#23- Specified ansible galaxy gluster.ifra to use the previous stable version v1.0.4-20

### DIFF
--- a/001.requirements.yml
+++ b/001.requirements.yml
@@ -5,14 +5,23 @@
   hosts: localhost
   become: no
   tasks:
+    
+    
     - name: "Install Ansible roles for GlusterFS"
       shell: "ansible-galaxy install -p $HOME/.ansible/roles -r requirements.yml --force"
 
     - name: "Install Ansible galaxy collection for GlusterFS volume support without specifying path"
       shell: "ansible-galaxy collection install gluster.gluster --force"
     
-    - name: "Install Ansible galaxy collection for GlusterFS volume support specifying path for AWS"
+    - name: "Install Ansible galaxy collection for GlusterFS volume support specifying path for AWS conf"
       shell: "ansible-galaxy collection install -p $HOME/.ansible/collections gluster.gluster --force"
+    
+    - name: "Install Ansible galaxy collection community.general"
+      shell: "ansible-galaxy collection install community.general --force"
+    
+    - name: "Install Ansible galaxy collection community.general for AWS conf"
+      shell: "ansible-galaxy collection install -p $HOME/.ansible/collections community.general --force"
+  
 
     - name: "Installing Jmespath through pip3"
       pip:

--- a/requirements.yml
+++ b/requirements.yml
@@ -5,3 +5,4 @@
     # Download gluster.infra from git
     - name: gluster.infra
       src: https://github.com/gluster/gluster-ansible-infra
+      version: v1.0.4-20


### PR DESCRIPTION
**Fix issue#23- Specified ansible galaxy gluster.ifra to use the previous stable version v1.0.4-20**

1) **Specified ansible galaxy [gluster.ifra](https://github.com/gluster/gluster-ansible-infra/tags) to use the previous stable version v1.0.4-20**

![Screenshot from 2022-04-26 13-43-40](https://user-images.githubusercontent.com/30879156/165294044-ad69ec6b-e762-4e19-bd6a-07f6993a6f19.png)

**2) installed  ansible galaxy community.general collection**
 **Reference :** https://stackoverflow.com/questions/71553629/getting-error-template-error-while-templating-string-no-filter-named-json-quer